### PR TITLE
Update WebServicesClient html page for executeDelete method with payload

### DIFF
--- a/static/rule-java-docs/sailpoint/connector/webservices/WebServicesClient.html
+++ b/static/rule-java-docs/sailpoint/connector/webservices/WebServicesClient.html
@@ -18,7 +18,7 @@
     catch(err) {
     }
 //-->
-var methods = {"i0":10,"i1":10,"i2":10,"i3":10,"i4":10,"i5":10,"i6":10,"i7":10,"i8":10,"i9":10,"i10":10,"i11":10,"i12":10};
+var methods = {"i0":10,"i1":10,"i2":10,"i3":10,"i4":10,"i5":10,"i6":10,"i7":10,"i8":10,"i9":10,"i10":10,"i11":10,"i12":10,"i13":10};
 var tabs = {65535:["t0","All Methods"],2:["t2","Instance Methods"],8:["t4","Concrete Methods"]};
 var altColor = "altColor";
 var rowColor = "rowColor";
@@ -188,12 +188,21 @@ extends java.lang.Object</pre>
 </tr>
 <tr id="i3" class="rowColor">
 <td class="colFirst"><code>java.lang.String</code></td>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#executeDelete-java.lang.String-java.util.Map-java.util.List-">executeDelete</a></span>(java.lang.String&nbsp;url,
+		   java.lang.Object&nbsp;payload,
+           java.util.Map&nbsp;headers,
+           java.util.List&lt;java.lang.String&gt;&nbsp;allowedStatuses)</code>
+<div class="block">Use this method to execute a DELETE call with specifying the url, payload, header values and allowed statuses.</div>
+</td>
+</tr>
+<tr id="i4" class="altColor">
+<td class="colFirst"><code>java.lang.String</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#executeGet-java.util.Map-java.util.List-">executeGet</a></span>(java.util.Map&nbsp;headers,
           java.util.List&lt;java.lang.String&gt;&nbsp;allowedStatuses)</code>
 <div class="block">Use this method to execute a GET call with specifying header values and allowed statuses.</div>
 </td>
 </tr>
-<tr id="i4" class="altColor">
+<tr id="i5" class="rowColor">
 <td class="colFirst"><code>java.lang.String</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#executeGet-java.lang.String-java.util.Map-java.util.List-">executeGet</a></span>(java.lang.String&nbsp;url,
           java.util.Map&nbsp;headers,
@@ -201,7 +210,7 @@ extends java.lang.Object</pre>
 <div class="block">Use this method to execute a GET call with specifying the url, header values and allowed statuses.</div>
 </td>
 </tr>
-<tr id="i5" class="rowColor">
+<tr id="i6" class="altColor">
 <td class="colFirst"><code>java.lang.String</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#executePatch-java.lang.String-java.lang.Object-java.util.List-">executePatch</a></span>(java.lang.String&nbsp;url,
             java.lang.Object&nbsp;payload,
@@ -209,7 +218,7 @@ extends java.lang.Object</pre>
 <div class="block">Use this method to execute a PATCH call with specifying the url, payload and allowed statuses.</div>
 </td>
 </tr>
-<tr id="i6" class="altColor">
+<tr id="i7" class="rowColor">
 <td class="colFirst"><code>java.lang.String</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#executePatch-java.lang.String-java.lang.Object-java.util.Map-java.util.List-">executePatch</a></span>(java.lang.String&nbsp;url,
             java.lang.Object&nbsp;payload,
@@ -218,7 +227,7 @@ extends java.lang.Object</pre>
 <div class="block">Use this method to execute a PATCH call with specifying the url, payload, header values and allowed statuses.</div>
 </td>
 </tr>
-<tr id="i7" class="rowColor">
+<tr id="i8" class="altColor">
 <td class="colFirst"><code>java.lang.String</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#executePost-java.lang.String-java.lang.Object-java.util.List-">executePost</a></span>(java.lang.String&nbsp;url,
            java.lang.Object&nbsp;payload,
@@ -226,7 +235,7 @@ extends java.lang.Object</pre>
 <div class="block">Use this method to execute a POST call with specifying the url, payload, and allowed statuses.</div>
 </td>
 </tr>
-<tr id="i8" class="altColor">
+<tr id="i9" class="rowColor">
 <td class="colFirst"><code>java.lang.String</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#executePost-java.lang.String-java.lang.Object-java.util.Map-java.util.List-">executePost</a></span>(java.lang.String&nbsp;url,
            java.lang.Object&nbsp;payload,
@@ -235,7 +244,7 @@ extends java.lang.Object</pre>
 <div class="block">Use this method to execute a POST call with specifying the url, payload, header values and allowed statuses.</div>
 </td>
 </tr>
-<tr id="i9" class="rowColor">
+<tr id="i10" class="altColor">
 <td class="colFirst"><code>java.lang.String</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#executePut-java.lang.String-java.lang.Object-java.util.List-">executePut</a></span>(java.lang.String&nbsp;url,
           java.lang.Object&nbsp;payload,
@@ -243,7 +252,7 @@ extends java.lang.Object</pre>
 <div class="block">Use this method to execute a PUT call with specifying the url, payload, and allowed statuses.</div>
 </td>
 </tr>
-<tr id="i10" class="altColor">
+<tr id="i11" class="rowColor">
 <td class="colFirst"><code>java.lang.String</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#executePut-java.lang.String-java.lang.Object-java.util.Map-java.util.List-">executePut</a></span>(java.lang.String&nbsp;url,
           java.lang.Object&nbsp;payload,
@@ -252,13 +261,13 @@ extends java.lang.Object</pre>
 <div class="block">Use this method to execute a PUT call with specifying the url, payload, header values and allowed statuses.</div>
 </td>
 </tr>
-<tr id="i11" class="rowColor">
+<tr id="i12" class="altColor">
 <td class="colFirst"><code>java.util.List</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#getCookies--">getCookies</a></span>()</code>
 <div class="block">Use this method to get a list of cookies associated with the request</div>
 </td>
 </tr>
-<tr id="i12" class="altColor">
+<tr id="i13" class="rowColor">
 <td class="colFirst"><code>java.util.Map&lt;java.lang.String,java.lang.String&gt;</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../sailpoint/connector/webservices/WebServicesClient.html#getResponseHeaders--">getResponseHeaders</a></span>()</code>
 <div class="block">Get the last executed request's response headers.</div>


### PR DESCRIPTION
Documentation is missing executeDelete method with payload information for restClient. 

For one of our developments, we used the executeDelete(java.lang.String url, java.lang.Object payload, java.util.Map headers, java.util.List<java.lang.String> allowedStatuses) method successfully.

Hence, updated the documentation with a new row to include the executeDelete method with payload information such that it could be useful for others too. I made sure the alternative table row color is properly modified too w.r.t the new entry.